### PR TITLE
モバイルページのヘッダーロゴ修正

### DIFF
--- a/themes/mdl_wwa/static/css/styles.css
+++ b/themes/mdl_wwa/static/css/styles.css
@@ -134,6 +134,7 @@ body {
   .fansq__header .header__title--mobile {
     display: block;
     margin: 0 auto;
+    width: 100%;
   }
   .card.card--stand-alone {
     margin: 48px 16px;


### PR DESCRIPTION
幅が狭いとロゴの右部分が切れるので、幅に応じてサイズを変えるように変更します。