### PR TITLE
お知らせのページ修正

### DIFF
--- a/layouts/information/single.html
+++ b/layouts/information/single.html
@@ -15,9 +15,9 @@
         </div>
         {{ end }}
         {{ partial "date.html" . }}
-        <div class="card__content mdl-card__supporting-text">
+        <article class="card__content mdl-card__supporting-text">
 {{ .Content }}
-        </div>
+        </article>
         <div class="card__footer mdl-card__actions">
             <a class="mdl-button mdl-button--colored" href="{{ .Site.BaseURL }}{{ .Section }}/">
                 <i class="material-icons">arrow_back</i> 戻る

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -103,10 +103,14 @@ article img {
     margin: 48px;
     padding: 32px 0;
 }
+    /* TODO: この後 .card__** が増えていく結末になるので、別途共通化出来るクラスを作るとかする。 */
     .card.card--stand-alone .card__header,
-    .card.card--stand-alone .card__content,
     .card.card--stand-alone .card__footer {
         padding: 0 32px;
+    }
+    .card.card--stand-alone .card__date,
+    .card.card--stand-alone .card__content {
+        padding: 16px 32px;
     }
 .card__date {
     font-size: 16px;

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -4,6 +4,11 @@ body {
     background: #f0e0c0;
 }
 
+article img {
+    width: 100%;
+    height: auto;
+}
+
 .invisible {
     visibility: hidden;
 }


### PR DESCRIPTION
お知らせのページでレイアウト崩れが多いので修正する。

元々はお知らせで利用するカードに余白を入れる形で解決していたものが、アイキャッチ画像の挿入で余白が入れず、カードで構成される要素一部一部に部分的に余白を入れていたため、レイアウトが上手く整っていない・・・という状況になっています。