### PR TITLE
お知らせ記事周りの余白を修正

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -4,6 +4,11 @@ body {
     background: #f0e0c0;
 }
 
+article ul,
+article ol {
+    padding-left: 1.5em;
+}
+
 article img {
     width: 100%;
     height: auto;

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -106,11 +106,14 @@ article img {
     /* TODO: この後 .card__** が増えていく結末になるので、別途共通化出来るクラスを作るとかする。 */
     .card.card--stand-alone .card__header,
     .card.card--stand-alone .card__footer {
-        padding: 0 32px;
+        padding: 0 4vw;
     }
     .card.card--stand-alone .card__date,
     .card.card--stand-alone .card__content {
-        padding: 16px 32px;
+        padding: 16px 4vw;
+    }
+    .card.card--stand-alone .card__content {
+        width: auto;
     }
 .card__date {
     font-size: 16px;


### PR DESCRIPTION
スマートフォンで見ると、お知らせの記事の右の余白がない状態になっています。
これだと見た目のバランスが悪いので、修正するPull Requestになります。

## 何が起こるの
- お知らせ記事を見てください。左右の余白がデバイスの幅単位で変わります。
- あとUL要素とOL要素の左余白が少し狭くなります。スマートフォンでも見やすくするための配慮です。